### PR TITLE
Improve chunker and add metrics

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
@@ -20,6 +22,9 @@ func StartAPIServer(logger *zap.Logger) {
 			"peers":  []string{"peer1", "peer2"},
 		})
 	})
+
+	// Expose Prometheus metrics
+	app.Get("/metrics", adaptor.HTTPHandler(promhttp.Handler()))
 
 	// Get the API port from configuration; default to 8080 if not set.
 	port := viper.GetInt("api.port")


### PR DESCRIPTION
## Summary
- avoid double-read in Chunker by hashing while chunking
- pool FlatBuffers builders for reuse
- expose `/metrics` endpoint for monitoring

## Testing
- `go vet ./...` *(fails: modules cannot be downloaded in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68564ea93b88832e94479161503dfde0